### PR TITLE
refactor: remove top level redundant catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,4 +61,4 @@ const createCheck = async function (title, summary) {
   })
 }
 
-run(core.getInput('defaultTag'), core.getInput('currentTag')).catch((error) => console.log(error))
+run(core.getInput('defaultTag'), core.getInput('currentTag'))


### PR DESCRIPTION
Since `run` already has `try/catch` I believe using `catch` again is redundant 